### PR TITLE
Add DFT project text

### DIFF
--- a/index.md
+++ b/index.md
@@ -17,8 +17,8 @@ The most universal approach to such predictions relies on quantum mechanics. We 
 
 {%
   include button.html
-  link="https://pubs.aip.org/aip/jcp/article/159/14/144113/2916356/KineticNet-Deep-learning-a-transferable-kinetic"
-  text="Our latest in Density Functional Theory"
+  link="projects"
+  text="Our projects"
   icon="fa-solid fa-arrow-right"
   flip=true
   style="bare"

--- a/index.md
+++ b/index.md
@@ -29,7 +29,7 @@ The most universal approach to such predictions relies on quantum mechanics. We 
 {%
   include feature.html
   image="images/density_slice.webp"
-  link="https://pubs.aip.org/aip/jcp/article/159/14/144113/2916356/KineticNet-Deep-learning-a-transferable-kinetic"
+  link="projects"
   title="Geometric Machine Learning in Quantum Chemistry"
   text=text
 %}

--- a/projects/index.md
+++ b/projects/index.md
@@ -13,6 +13,12 @@ nav:
 
 **What is the kinetic energy of a given ground state electron density? While we know the question holds a significant answer, irritatingly, we do not know how to find it.**
 
+{%
+  include figure.html
+  image="images/density_slice.webp"
+  width="700px"
+%}
+
 When predicting the properties of a molecule, it is possible to simplify by separating nuclear and electronic degrees of freedom. The latter are the subject of Electronic Structure Theory, which invokes quantum mechanics to describe the interacting electrons in terms of their many-body wave function $\psi(x_1, ..., x_N)$. For sizeable molecules, this is too expensive and instead Kohn-Sham density functional theory (DFT) is evoked. The latter models the same system merely via one-body functions $\phi_1 (x_1)$, ..., $\phi_N (x_N)$ describing non-interacting electrons moving in an effective potential created by the others. Importantly, these functions lead in principle to the exact electron density $\rho_\mathrm{exact}$, however, approximations for the unknown exchange-correlation energy functionals need to be made. Although highly successful in practice, Kohn-Sham DFT remains a sort of band-aid solution. Why? 
 
 
@@ -21,6 +27,8 @@ In the 1960s, Hohenberg and Kohn made a tantalizing discovery: for systems in th
 Being able to do so is not only of great theoretical interest: it paves the way for variationally optimizing the electronic ground state density without taking recourse to the much more complicated many-body wave functions. This sixty-year old promise, called pure or, more contemporarily, orbital-free DFT, promises computing molecular properties with a complexity growing merely linearly with system size.
 
 The entire team is now focused on developing machine learning methods to *learn* the elusive functional. If successful, this will dramatically speed up the prediction of molecular properties, paving the way to address previously inaccessible questions in the molecular and life sciences. 
+
+{% include citation.html %}
 
 {% include list.html component="card" data="projects" filters="group: featured" %}
 

--- a/projects/index.md
+++ b/projects/index.md
@@ -28,9 +28,9 @@ Being able to do so is not only of great theoretical interest: it paves the way 
 
 The entire team is now focused on developing machine learning methods to *learn* the elusive functional. If successful, this will dramatically speed up the prediction of molecular properties, paving the way to address previously inaccessible questions in the molecular and life sciences. 
 
-{% include citation.html %}
+{% include list.html data="citations" component="citation" filters="id: doi:10.1063/5.0158275" style="rich" %}
 
-{% include list.html component="card" data="projects" filters="group: featured" %}
+<!-- {% include list.html component="card" data="projects" filters="group: featured" %} -->
 
 {% include section.html %}
 

--- a/projects/index.md
+++ b/projects/index.md
@@ -28,9 +28,8 @@ Being able to do so is not only of great theoretical interest: it paves the way 
 
 The entire team is now focused on developing machine learning methods to *learn* the elusive functional. If successful, this will dramatically speed up the prediction of molecular properties, paving the way to address previously inaccessible questions in the molecular and life sciences. 
 
-{% include list.html data="citations" component="citation" filters="id: doi:10.1063/5.0158275" style="rich" %}
+{% include list.html data="citations" component="citation" filters="title: KineticNet: Deep learning a transferable kinetic energy functional for orbital-free density functional theory" style="rich" %}
 
-<!-- {% include list.html component="card" data="projects" filters="group: featured" %} -->
 
 {% include section.html %}
 

--- a/projects/index.md
+++ b/projects/index.md
@@ -16,7 +16,8 @@ nav:
 {%
   include figure.html
   image="images/density_slice.webp"
-  width="700px"
+  width="400px"
+  caption="Slice through the density difference to the ground state of a molecule."
 %}
 
 When predicting the properties of a molecule, it is possible to simplify by separating nuclear and electronic degrees of freedom. The latter are the subject of Electronic Structure Theory, which invokes quantum mechanics to describe the interacting electrons in terms of their many-body wave function $\psi(x_1, ..., x_N)$. For sizeable molecules, this is too expensive and instead Kohn-Sham density functional theory (DFT) is evoked. The latter models the same system merely via one-body functions $\phi_1 (x_1)$, ..., $\phi_N (x_N)$ describing non-interacting electrons moving in an effective potential created by the others. Importantly, these functions lead in principle to the exact electron density $\rho_\mathrm{exact}$, however, approximations for the unknown exchange-correlation energy functionals need to be made. Although highly successful in practice, Kohn-Sham DFT remains a sort of band-aid solution. Why? 

--- a/projects/index.md
+++ b/projects/index.md
@@ -13,6 +13,8 @@ nav:
 
 **What is the kinetic energy of a given ground state electron density? While we know the question holds a significant answer, irritatingly, we do not know how to find it.**
 
+When predicting the properties of a molecule, it is possible to simplify by separating nuclear and electronic degrees of freedom. The latter are the subject of Electronic Structure Theory, which invokes quantum mechanics to describe the interacting electrons in terms of their many-body wave function $\psi(x_1, ..., x_N)$. For sizeable molecules, this is too expensive and instead Kohn-Sham density functional theory (DFT) is evoked. The latter models the same system merely via one-body functions $\phi_1 (x_1)$, ..., $\phi_N (x_N)$ describing non-interacting electrons moving in an effective potential created by the others. Importantly, these functions lead in principle to the exact electron density $\rho_\mathrm{exact}$, however, approximations for the unknown exchange-correlation energy functionals need to be made. Although highly successful in practice, Kohn-Sham DFT remains a sort of band-aid solution. Why? 
+
 {%
   include figure.html
   image="images/density_slice.webp"
@@ -20,7 +22,6 @@ nav:
   caption="Slice through the density difference to the ground state of a molecule."
 %}
 
-When predicting the properties of a molecule, it is possible to simplify by separating nuclear and electronic degrees of freedom. The latter are the subject of Electronic Structure Theory, which invokes quantum mechanics to describe the interacting electrons in terms of their many-body wave function $\psi(x_1, ..., x_N)$. For sizeable molecules, this is too expensive and instead Kohn-Sham density functional theory (DFT) is evoked. The latter models the same system merely via one-body functions $\phi_1 (x_1)$, ..., $\phi_N (x_N)$ describing non-interacting electrons moving in an effective potential created by the others. Importantly, these functions lead in principle to the exact electron density $\rho_\mathrm{exact}$, however, approximations for the unknown exchange-correlation energy functionals need to be made. Although highly successful in practice, Kohn-Sham DFT remains a sort of band-aid solution. Why? 
 
 
 In the 1960s, Hohenberg and Kohn made a tantalizing discovery: for systems in their electronic ground state, knowledge of the electron density alone suffices to compute the exact electronic ground state energy, and wave functions or “orbitals” are not needed! To find the ground state electron density, one minimizes its overall energy in the potential created by atomic nuclei. The overall energy has, of course, a kinetic contribution stemming from the kinetic energy density functional $E_\mathrm{kin} = T[\rho_\mathrm{exact}]$. Vexingly, it has so far been impossible to identify the functional $T[\rho]$ yielding the exact kinetic energy of a given ground state electron density.

--- a/projects/index.md
+++ b/projects/index.md
@@ -11,9 +11,7 @@ nav:
 
 ## Current focus: Orbital-free density functional theory
 
-**What is the kinetic energy of a given ground state electron density? While we know the question holds a significant answer, irritatingly, we do not know how to find it.**
-
-When predicting the properties of a molecule, it is possible to simplify by separating nuclear and electronic degrees of freedom. The latter are the subject of Electronic Structure Theory, which invokes quantum mechanics to describe the interacting electrons in terms of their many-body wave function $\psi(x_1, ..., x_N)$. For sizeable molecules, this is too expensive and instead Kohn-Sham density functional theory (DFT) is evoked. The latter models the same system merely via one-body functions $\phi_1 (x_1)$, ..., $\phi_N (x_N)$ describing non-interacting electrons moving in an effective potential created by the others. Importantly, these functions lead in principle to the exact electron density $\rho_\mathrm{exact}$, however, approximations for the unknown exchange-correlation energy functionals need to be made. Although highly successful in practice, Kohn-Sham DFT remains a sort of band-aid solution. Why? 
+**What is the kinetic energy of a given molecular ground state electron density? While the answer matters, and is known to exist in principle, so far no-one knows how to find it.**
 
 {%
   include figure.html
@@ -22,11 +20,9 @@ When predicting the properties of a molecule, it is possible to simplify by sepa
   caption="Slice through the density difference to the ground state of a molecule."
 %}
 
+When predicting the properties of a molecule, it is natural to invoke quantum mechanics to describe the interacting electrons in terms of their many-body wave function $\psi(x_1, ..., x_N)$. For sizeable molecules, this is too expensive and instead Kohn-Sham density functional theory (KS-DFT) is routinely evoked. The latter models the same system merely via one-body functions $\phi_1 (x_1)$, ..., $\phi_N (x_N)$ describing non-interacting electrons moving in an effective potential created by all others. Although highly successful in practice, Kohn-Sham DFT remains a sort of band-aid solution. Why? 
 
-
-In the 1960s, Hohenberg and Kohn made a tantalizing discovery: for systems in their electronic ground state, knowledge of the electron density alone suffices to compute the exact electronic ground state energy, and wave functions or “orbitals” are not needed! To find the ground state electron density, one minimizes its overall energy in the potential created by atomic nuclei. The overall energy has, of course, a kinetic contribution stemming from the kinetic energy density functional $E_\mathrm{kin} = T[\rho_\mathrm{exact}]$. Vexingly, it has so far been impossible to identify the functional $T[\rho]$ yielding the exact kinetic energy of a given ground state electron density.
-
-Being able to do so is not only of great theoretical interest: it paves the way for variationally optimizing the electronic ground state density without taking recourse to the much more complicated many-body wave functions. This sixty-year old promise, called pure or, more contemporarily, orbital-free DFT, promises computing molecular properties with a complexity growing merely linearly with system size.
+In the 1960s, Hohenberg and Kohn made a tantalizing discovery: for systems in their electronic ground state, knowledge of the electron density alone suffices to infer the exact electronic ground state energy, and wave functions or “orbitals” are not needed! To find the ground state electron density, one minimizes its overall energy in the potential created by atomic nuclei. The overall energy has, of course, a kinetic contribution. Vexingly, it has so far been impossible to identify the functional $T[\rho]$ yielding the exact kinetic energy of a given ground state electron density $\rho$. Finding this functional is, on the one hand, of great theoretical interest. At the same time, it paves the way for optimizing the  ground state electron density without taking recourse to the much more complicated many-body wave functions. This sixty-year old promise is called “pure” or “orbital-free” DFT. 
 
 The entire team is now focused on developing machine learning methods to *learn* the elusive functional. If successful, this will dramatically speed up the prediction of molecular properties, paving the way to address previously inaccessible questions in the molecular and life sciences. 
 

--- a/projects/index.md
+++ b/projects/index.md
@@ -9,7 +9,18 @@ nav:
 
 {% include section.html %}
 
-## Current focus
+## Current focus: Orbital-free density functional theory
+
+**What is the kinetic energy of a given ground state electron density? While we know the question holds a significant answer, irritatingly, we do not know how to find it.**
+
+When predicting the properties of a molecule, it is possible to simplify by separating nuclear and electronic degrees of freedom. The latter are the subject of Electronic Structure Theory, which invokes quantum mechanics to describe the interacting electrons in terms of their many-body wave function $\psi(x_1, ..., x_N)$. For sizeable molecules, this is too expensive and instead Kohn-Sham density functional theory (DFT) is evoked. The latter models the same system merely via one-body functions $\phi_1 (x_1)$, ..., $\phi_N (x_N)$ describing non-interacting electrons moving in an effective potential created by the others. Importantly, these functions lead in principle to the exact electron density $\rho_\mathrm{exact}$, however, approximations for the unknown exchange-correlation energy functionals need to be made. Although highly successful in practice, Kohn-Sham DFT remains a sort of band-aid solution. Why? 
+
+
+In the 1960s, Hohenberg and Kohn made a tantalizing discovery: for systems in their electronic ground state, knowledge of the electron density alone suffices to compute the exact electronic ground state energy, and wave functions or “orbitals” are not needed! To find the ground state electron density, one minimizes its overall energy in the potential created by atomic nuclei. The overall energy has, of course, a kinetic contribution stemming from the kinetic energy density functional $E_\mathrm{kin} = T[\rho_\mathrm{exact}]$. Vexingly, it has so far been impossible to identify the functional $T[\rho]$ yielding the exact kinetic energy of a given ground state electron density.
+
+Being able to do so is not only of great theoretical interest: it paves the way for variationally optimizing the electronic ground state density without taking recourse to the much more complicated many-body wave functions. This sixty-year old promise, called pure or, more contemporarily, orbital-free DFT, promises computing molecular properties with a complexity growing merely linearly with system size.
+
+The entire team is now focused on developing machine learning methods to *learn* the elusive functional. If successful, this will dramatically speed up the prediction of molecular properties, paving the way to address previously inaccessible questions in the molecular and life sciences. 
 
 {% include list.html component="card" data="projects" filters="group: featured" %}
 


### PR DESCRIPTION
The link on the homepage points to the projects site. There, a more detailed description is added.